### PR TITLE
Add enum to status field

### DIFF
--- a/pg_backup_api/pg_backup_api/spec/pg_backup_api.yaml
+++ b/pg_backup_api/pg_backup_api/spec/pg_backup_api.yaml
@@ -538,6 +538,13 @@ components:
           status:
             description: The current status of the backup
             type: string
+            enum:
+              - DONE
+              - EMPTY
+              - FAILED
+              - STARTED
+              - SYNCING
+              - WAITING_FOR_WALS
           systemid:
             description: >
               The system identifier of the PostgreSQL server from which the backup


### PR DESCRIPTION
Adds the enum keyword to the status field with the list of possible
status values according to Barman as of the following commit:

  - https://github.com/EnterpriseDB/barman/blob/f3104b0cc1447ebf1bf64ec74e773e4eb16e7eb9/barman/infofile.py#L413-L423

---

Not sure what openapi-generator does with enums but apparently not very much since the generated code did not change.