### PR TITLE
Specify full package path in fpm

### DIFF
--- a/.github/workflows/publish-to-cloudsmith.yml
+++ b/.github/workflows/publish-to-cloudsmith.yml
@@ -72,14 +72,6 @@ jobs:
             --platform-version ${{ env.PLATFORM_VERSION }} \
             --version ${{ env.FULL_VERSION }} \
             --debug
-      - name: Rename package file
-        working-directory: ./packaging
-        env:
-          PLATFORM_VERSION: ${{ matrix.platform_version }}
-        run: |
-          mv \
-            pg-backup-api_${{env.FULL_VERSION}}-${{env.RELEASE_VERSION}}_amd64.deb \
-            pg-backup-api_${{env.FULL_VERSION}}-${{env.RELEASE_VERSION}}.${{env.PLATFORM_VERSION}}_amd64.deb
       - name: Push pg-backup-api DEB to CloudSmith Repo
         env:
           PLATFORM_FLAVOUR: ${{ matrix.platform_flavour }}
@@ -162,15 +154,6 @@ jobs:
             --platform-version ${{ env.PLATFORM_VERSION }} \
             --version ${{ env.FULL_VERSION }} \
             --debug
-      - name: Rename package file
-        working-directory: ./packaging
-        env:
-          PLATFORM_FLAVOUR: ${{ matrix.platform_flavour }}
-          PLATFORM_VERSION: ${{ matrix.platform_version }}
-        run: |
-          mv \
-            pg-backup-api-${{env.FULL_VERSION}}-${{env.RELEASE_VERSION}}.x86_64.rpm \
-            pg-backup-api-${{env.FULL_VERSION}}-${{env.RELEASE_VERSION}}.${{env.PLATFORM_FLAVOUR}}${{env.PLATFORM_VERSION}}.x86_64.rpm
       - name: Push pg-backup-api RPM to CloudSmith Repo
         env:
           PLATFORM_FLAVOUR: ${{ matrix.platform_flavour }}

--- a/packaging/pkg.sh
+++ b/packaging/pkg.sh
@@ -79,10 +79,12 @@ if [ "$PKG_TYPE" = "deb" ]
 then
     extra_opts="--deb-systemd ../packaging/build/etc/systemd/system/pg-backup-api.service \
                 --deb-systemd-enable"
+    package_name="pg-backup-api_${VERSION}-${RELEASE_VERSION}.${PLATFORM_VERSION}_amd64.deb"
 elif [ "$PKG_TYPE" = "rpm" ]
 then
     extra_opts="--virtualenv-other-files-dir ../packaging/build \
                 --directories /usr/bin/pgbapi-venv"
+    package_name="pg-backup-api-${VERSION}-${RELEASE_VERSION}.${PLATFORM_FLAVOUR}${PLATFORM_VERSION}.x86_64.rpm"
 else
     echo "Valid package types are rpm or deb."
     exit 1
@@ -115,7 +117,7 @@ fpm $DBG_SETTINGS \
     -t $PKG_TYPE \
     -d "barman > 2.16" \
     -d $PYTHON_PACKAGE_DEP \
-    -p ../packaging \
+    -p ../packaging/$package_name \
     -n pg-backup-api \
     -v $VERSION \
     --prefix /usr/bin/pgbapi-venv \


### PR DESCRIPTION
Updates the `-p` option passed to fpm to include the full package
file name. This allows us to remove the rename steps from the
workflow.