### PR TITLE
Make the size field nullable

### DIFF
--- a/pg_backup_api/pg_backup_api/spec/pg_backup_api.yaml
+++ b/pg_backup_api/pg_backup_api/spec/pg_backup_api.yaml
@@ -572,6 +572,7 @@ components:
             type: string
           size:
             description: The size of the backup in bytes
+            nullable: true
             type: integer
           status:
             description: The current status of the backup


### PR DESCRIPTION
The `barman diagnose` output can produce `null` values for size when
certain backup failures occur - the schema is therefore updated to
specify that `size` is nullable.

Closes #40.