### PR TITLE
Remove internal barman dependency

### DIFF
--- a/pg_backup_api/pg_backup_api/run.py
+++ b/pg_backup_api/pg_backup_api/run.py
@@ -24,8 +24,6 @@ from logging.config import dictConfig
 import requests
 from requests.exceptions import ConnectionError
 
-import barman
-from barman import config, output
 from pg_backup_api.openapi_server import encoder
 
 
@@ -36,13 +34,6 @@ def serve(args):
     """
     Run the Postgres Backup API app.
     """
-    # TODO determine backup tool setup based on config
-    # load barman configs/setup barman for the app
-    cfg = config.Config("/etc/barman.conf")
-    barman.__config__ = cfg
-    cfg.load_configuration_files_directory()
-    output.set_output_writer(output.AVAILABLE_WRITERS["json"]())
-
     # setup and run the app
     app = connexion.App(__name__, specification_dir="./spec/")
     app.app.json_encoder = encoder.JSONEncoder

--- a/pg_backup_api/requirements.txt
+++ b/pg_backup_api/requirements.txt
@@ -1,6 +1,5 @@
 argcomplete==2.0.0
 attrs==21.4.0
-barman>=3.0.0
 certifi==2021.10.8
 charset-normalizer==2.0.10
 click==8.0.3
@@ -18,7 +17,6 @@ jsonschema==3.2.0
 MarkupSafe==2.0.1
 openapi-schema-validator==0.1.6
 openapi-spec-validator==0.3.2
-psycopg2==2.9.3
 pyrsistent==0.16.1
 python-dateutil==2.8.2
 PyYAML==5.4.1

--- a/pg_backup_api/setup.py
+++ b/pg_backup_api/setup.py
@@ -32,7 +32,6 @@ with open("./version.txt", "r") as f:
 # http://pypi.python.org/pypi/setuptools
 
 REQUIRES = [
-    "barman>=3.0.0",
     "connexion>=2.0.2",
     "jsonschema==3.2.0",
     "pyrsistent==0.16.1",


### PR DESCRIPTION
Update the way we fetch the barman diagnose output by shelling out to
the barman diagnose command directly rather than using an internal
barman as a library.

Although in one sense this is a step backward, it brings the following
benefits:

 * The barman version reported by pg-backup-api will be that of the
   system barman (closes #24).
 * pg-backup-api versions will no longer be dependent on barman versions
   so it will no longer be necessary to update pg-backup-api with a new
   internal barman if a new barman release contains breaking changes.
 * We can remove several dependencies which will result in a smaller
   venv in the packages.

The real fix for these issues is to package pg-backup-api like a system
python package so that it can use the system barman as a library (and
therefore does not have to shell out to the barman diagnose command)
however this is complicated because:

  * RHEL platforms lack certain critical dependencies which means as
    well as packaging connexions we must package up to seven other
    dependencies for EL 7/8 and SLES 12/15. This is a maintenance
    burden.
  * Debian platforms also require us to package up some extra
    python dependencies though not as many as for RHEL.
  * We cannot support python2 platforms with this approach at all
    because connexions requires python3 and we package the system barman
    for python2. Though we are trying to drop python2 support in barman
    we are not there yet (to do so requires us to package for python3
    on CentOS 7 (this is feasible) and SLES 12 (not as feasible due to
    lots of missing dependencies).

Closes #43.