### PR TITLE
Reload Barman config before generating diagnose output

### DIFF
--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -23,10 +23,13 @@ from barman import diagnose, output
 from barman.server import Server
 from pg_backup_api.openapi_server.util import deserialize_model
 from pg_backup_api.openapi_server.models.diagnose_output import DiagnoseOutput
+from pg_backup_api.utils import load_barman_config
 
 
 class UtilityController:
     def diagnose(self):
+        # Reload the barman config so that any changes are picked up
+        load_barman_config()
         # Get every server (both inactive and temporarily disabled)
         servers = barman.__config__.server_names()
 

--- a/pg_backup_api/pg_backup_api/run.py
+++ b/pg_backup_api/pg_backup_api/run.py
@@ -24,9 +24,9 @@ from logging.config import dictConfig
 import requests
 from requests.exceptions import ConnectionError
 
-import barman
-from barman import config, output
+from barman import output
 from pg_backup_api.openapi_server import encoder
+from pg_backup_api.utils import load_barman_config
 
 
 LOG_FILENAME = "/var/log/barman/barman-api.log"  # TODO make configurable
@@ -38,9 +38,7 @@ def serve(args):
     """
     # TODO determine backup tool setup based on config
     # load barman configs/setup barman for the app
-    cfg = config.Config("/etc/barman.conf")
-    barman.__config__ = cfg
-    cfg.load_configuration_files_directory()
+    load_barman_config()
     output.set_output_writer(output.AVAILABLE_WRITERS["json"]())
 
     # setup and run the app

--- a/pg_backup_api/pg_backup_api/utils.py
+++ b/pg_backup_api/pg_backup_api/utils.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# © Copyright EnterpriseDB UK Limited 2021-2022
+#
+# This file is part of Postgres Backup API.
+#
+# Postgres Backup API is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Postgres Backup API is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Postgres Backup API.  If not, see <http://www.gnu.org/licenses/>.
+
+import barman
+from barman import config
+
+CONFIG_FILENAME = "/etc/barman.conf"
+
+
+def load_barman_config():
+    """
+    Load the Barman config into barman.__config__.
+    """
+    cfg = config.Config(CONFIG_FILENAME)
+    barman.__config__ = cfg
+    cfg.load_configuration_files_directory()


### PR DESCRIPTION
Reloads the Barman config when handling diagnose requests. This fixes two issues:

1. Config changes would not be included in the diagnose output until pg-backup-api had restarted (#56).
2. `msg_list` would never be cleared so each time the diagnose endpoint was called the new messages would be appended (#55).

Closes #55.
Closes #56.