### PR TITLE
BAR-45 Supporting barman shortcuts

### DIFF
--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -26,7 +26,7 @@ import barman
 from barman import diagnose as barman_diagnose, output
 from barman.server import Server
 
-from pg_backup_api.utils import load_barman_config, get_server_by_name
+from pg_backup_api.utils import load_barman_config, get_server_by_name, parse_backup_id
 
 from pg_backup_api.run import app
 from pg_backup_api.server_operation import ServerOperation, ServerOperationConfigError
@@ -101,9 +101,9 @@ def servers_operations_post(server_name, request):
         message_404 = "Server '{}' does not exist".format(server_name)
         abort(404, description=message_404)
 
-    backup_id = request_body["backup_id"]
     server_object = Server(server)
-    if not server_object.get_backup(backup_id):
+    backup_id = parse_backup_id(server_object, request_body["backup_id"])
+    if not backup_id:
         message_404 = "Backup '{}' does not exist".format(server_name)
         abort(404, description=message_404)
 

--- a/pg_backup_api/pg_backup_api/utils.py
+++ b/pg_backup_api/pg_backup_api/utils.py
@@ -22,6 +22,7 @@ from flask import Flask
 
 import barman
 from barman import config
+from barman.infofile import BackupInfo
 
 API_CONFIG = {"supported_options": ("remote_ssh_command",)}
 
@@ -76,3 +77,14 @@ def get_server_by_name(server_name):
         conf = barman.__config__.get_server(server)
         if server == server_name:
             return conf
+
+
+def parse_backup_id(server, backup_id):
+    if backup_id in ("latest", "last"):
+        backup_id = server.get_last_backup_id()
+    elif backup_id in ("oldest", "first"):
+        backup_id = server.get_first_backup_id()
+    elif args.backup_id in ("last-failed"):
+        backup_id = server.get_last_backup_id([BackupInfo.FAILED])
+
+    return server.get_backup(backup_id)


### PR DESCRIPTION
So far pg-backup-api was calling get_backup() which always receives the `backup_id` as argument. In order to support barman shortcuts like "latest" for instance, we need to find out the backup_id first and call get_backup() afterwards.

This step was not considered beforehand when we released pg-backup-api v1.1 but customers are already expecting to use such feature with barman.