### PR TITLE
setup.py: dashes is preferred in pkgs names

### DIFF
--- a/pg_backup_api/setup.py
+++ b/pg_backup_api/setup.py
@@ -19,10 +19,10 @@
 import sys
 from setuptools import setup, find_packages
 
-NAME = "pg_backup_api"
+NAME = "pg-backup-api"
 
 with open("./version.txt", "r") as f:
-    VERSION = f.readline()
+    VERSION = f.readline().rstrip()
 
 # To install the library, run the following
 #


### PR DESCRIPTION
This is required in packaging for the integration with Foundation