### PR TITLE
Refactor setup_logging function.

### DIFF
--- a/pg_backup_api/pg_backup_api/app.py
+++ b/pg_backup_api/pg_backup_api/app.py
@@ -19,9 +19,12 @@
 from barman import output
 
 from pg_backup_api.run import app
-from pg_backup_api.utils import load_barman_config, setup_logging
+from pg_backup_api.utils import (
+    load_barman_config,
+    setup_logging_for_wsgi_server
+)
 
 load_barman_config()
-setup_logging()
+setup_logging_for_wsgi_server()
 output.set_output_writer(output.AVAILABLE_WRITERS["json"]())
 application = app

--- a/pg_backup_api/pg_backup_api/run.py
+++ b/pg_backup_api/pg_backup_api/run.py
@@ -29,7 +29,6 @@ from pg_backup_api.utils import (
     API_CONFIG,
     create_app,
     load_barman_config,
-    setup_logging,
 )
 from pg_backup_api.server_operation import ServerOperation
 
@@ -104,8 +103,6 @@ def main():
     """
     Main method of the Postgres Backup API API app
     """
-    setup_logging()
-
     p = argparse.ArgumentParser(
         epilog="Postgres Backup API by EnterpriseDB (www.enterprisedb.com)"
     )

--- a/pg_backup_api/pg_backup_api/utils.py
+++ b/pg_backup_api/pg_backup_api/utils.py
@@ -45,7 +45,7 @@ def load_barman_config():
     cfg.load_configuration_files_directory()
 
 
-def setup_logging():
+def setup_logging_for_wsgi_server():
     """
     Configure logging.
     """


### PR DESCRIPTION
The latest workflow I userd to test this change:
 https://github.com/EnterpriseDB/pg-backup-api-packaging/actions/runs/5159374097/jobs/9294268806

We don't need to call this function from the start. One reason is if we do, we need to check that we run the program as the `barman` user but if we just need to check a job we sent for instance, this check is not really required.

We can query the endpoints using plan text requests with curl. So for now, the only time when we need the `barman` user is when gunicorn is started because the logs are going to be written to a barman owned file, hence rw access is needed.

Also, the function was renamed to setup_logging_for_wsgi_server().

This traceback is shown without this change:
 Traceback (most recent call last):
  File "/usr/lib64/python3.6/logging/config.py", line 565, in configure
    handler = self.configure_handler(handlers[name])
  File "/usr/lib64/python3.6/logging/config.py", line 738, in configure_handler
    result = factory(**kwargs)
  File "/usr/lib64/python3.6/logging/__init__.py", line 1032, in __init__
    StreamHandler.__init__(self, self._open())
  File "/usr/lib64/python3.6/logging/__init__.py", line 1061, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding)
PermissionError: [Errno 13] Permission denied: '/var/log/barman/barman-api.log'