### PR TITLE
Fix `Backup 'X' does not exist` message`

### DIFF
--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -104,7 +104,7 @@ def servers_operations_post(server_name, request):
     server_object = Server(server)
     backup_id = parse_backup_id(server_object, request_body["backup_id"])
     if not backup_id:
-        message_404 = "Backup '{}' does not exist".format(server_name)
+        message_404 = "Backup '{}' does not exist".format(backup_id)
         abort(404, description=message_404)
 
     operation_id = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")


### PR DESCRIPTION
The message was referencing the server name instead of the backup ID.