### PR TITLE
Improve `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,88 @@
 # pg-backup-api
-A server that provides an HTTP API to interact with Postgres backups
+
+A server that provides an REST API to interact with Barman.
 
 ## Installation
-tbd
+
+This tool is supposed to be installed in the same server where Barman is already
+set up and running.
+
+### Package installation
+
+Configure EDB repos 2.0 and install the package `pg-backup-api` using your
+package manager.
+
+### Installation from source code
+
+1. Clone this repository, e.g.:
+
+```bash
+git clone https://github.com/EnterpriseDB/pg-backup-api.git
+```
+
+2. Install `pg-backup-api` and its requirements:
+
+```bash
+cd pg-backup-api/pg_backup_api
+sudo python3 setup.py install
+```
+
+**Note:** `pg_config` application should be in your `PATH` because `psycopg2` is
+in the dependency tree. Besides that, you also need the `libpq` C library in
+your system (`libpq-dev` package on Debian based, or `libpq-devel` package on
+RedHat based).
 
 ## Running the Flask app
 
 ### Manually
 
-Install `pg-backup-api` and change to the Barman user, then run
+As Barman user run:
 
-`pg-backup-api serve` 
+```bash
+pg-backup-api serve
+```
 
-or `pg-backup-api serve --port N` if you want to use a different port than the default (which is 7480).
+**Note:** by default `pg-backup-api` runs on port `7480`. You can override that
+behavior by passing `--port N` to `serve` command, `N` being the port to listen
+on.
 
 ### Service
 
-If running from a local source directory, copy `pg-backup-api/packaging/pg-backup-api.service` to `/etc/systemd/system/`. If you've installed
-pg-backup-api as a package, installation will put the service file in the right place for you.
+If you are running `pg-backup-api` from a local source directory, copy
+`pg-backup-api/packaging/pg-backup-api.service` to `/etc/systemd/system/`. If
+you've installed `pg-backup-api` as a package, installation puts the service
+file in the right place for you.
 
-Then run
-`systemctl enable pg-backup-api`
-`systemctl start pg-backup-api`
+Once the systemd services are in the right place, run the following command to
+enable `pg-backup-api` startup on machine boot, and immediatelly start it:
 
-to run it.
+```bash
+systemctl enable pg-backup-api --now
+```
 
 ### Verify the app
 
-`pg-backup-api status` returns "OK" if the app is up and running.
+You can check if the application is up and running by executing this command:
+
+```bash
+pg-backup-api status
+```
+
+The command returns `"OK"` if the app is up and running.
 
 ## Testing
-tbd
+
+You can run unit tests through `pytest`:
+
+```bash
+cd pg-backup-api/pg_backup_api
+python3 -m pytest
+```
+
+**Note:** install `pytest` Python module if you don't have it yet in your
+environment.
 
 ## Releasing
 
-Follow the process documented in the [pg-backup-api-packaging repo](https://github.com/EnterpriseDB/pg-backup-api-packaging).
+Follow the process documented in the
+[pg-backup-api-packaging repo](https://github.com/EnterpriseDB/pg-backup-api-packaging).

--- a/README.md
+++ b/README.md
@@ -46,12 +46,22 @@ pg-backup-api serve
 behavior by passing `--port N` to `serve` command, `N` being the port to listen
 on.
 
+The above comand will start up the REST API as a development server. If you
+want to run the REST API as an WSGI application, use the approach described in
+the `Service` section.
+
 ### Service
 
-If you are running `pg-backup-api` from a local source directory, copy
-`pg-backup-api/packaging/pg-backup-api.service` to `/etc/systemd/system/`. If
-you've installed `pg-backup-api` as a package, installation puts the service
-file in the right place for you.
+If you intend to run `pg-backup-api` from a local source directory, then you
+need to set up the `pg-backup-api` service. You need to copy a couple files
+from the [pg-backup-api-packaging repo](https://github.com/EnterpriseDB/pg-backup-api-packaging):
+
+1. Copy `packaging/etc/systemd/system/pg-backup-api.service.in` to
+   `/etc/systemd/system/pg-backup-api.service`
+2. Copy `packaging/etc/pg-backup-api-config.py` to `/etc/pg-backup-api-config.py`
+
+If you have installed the `pg-backup-api` package, the package installation puts
+the service and configuration files in the right place for you.
 
 Once the systemd services are in the right place, run the following command to
 enable `pg-backup-api` startup on machine boot, and immediatelly start it:
@@ -59,6 +69,9 @@ enable `pg-backup-api` startup on machine boot, and immediatelly start it:
 ```bash
 systemctl enable pg-backup-api --now
 ```
+
+**Note:** by default the `pg-backup-api` service runs on port `7480`. You can
+override that behavior by changing the port in `/etc/pg-backup-api-config.py`.
 
 ### Verify the app
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ from the [pg-backup-api-packaging repo](https://github.com/EnterpriseDB/pg-backu
 If you have installed the `pg-backup-api` package, the package installation puts
 the service and configuration files in the right place for you.
 
-Once the systemd services are in the right place, run the following command to
-enable `pg-backup-api` startup on machine boot, and immediatelly start it:
+Once the systemd services are in place, run the following command to enable
+`pg-backup-api` startup on machine boot, and immediatelly start it:
 
 ```bash
 systemctl enable pg-backup-api --now


### PR DESCRIPTION
This PR introduces the following changes:

* Add information about `pg-backup-api` installation, both from packages and from source code;
* Modify the existing section about how to run `pg-backup-api`, adding more complete information and fixing incorrect information;
* Add information about testing `pg-backup-api`.

Besides that it also attempts to reformat the `README.md` for a more fluid reading.

References: BAR-90.