### PR TITLE
Perform a small code refactoring of `pg-backup-api`

### DIFF
--- a/pg_backup_api/pg_backup_api/__init__.py
+++ b/pg_backup_api/pg_backup_api/__init__.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU General Public License
 # along with Postgres Backup API.  If not, see <http://www.gnu.org/licenses/>.
 
-import pg_backup_api.logic.utility_controller
+import pg_backup_api.logic.utility_controller  # noqa: F401

--- a/pg_backup_api/pg_backup_api/__main__.py
+++ b/pg_backup_api/pg_backup_api/__main__.py
@@ -32,17 +32,33 @@ def main():
 
     subparsers = p.add_subparsers()
 
-    p_serve = subparsers.add_parser("serve")
-    p_serve.add_argument("--port", type=int, default=7480)
+    p_serve = subparsers.add_parser(
+        "serve",
+        description="Start the REST API server. Listen for requests on "
+                    "'127.0.0.1', on the given port.",
+    )
+    p_serve.add_argument("--port", type=int, default=7480,
+                         help="Port to bind to.")
     p_serve.set_defaults(func=serve)
 
-    p_status = subparsers.add_parser("status")
-    p_status.add_argument("--port", type=int, default=7480)
+    p_status = subparsers.add_parser(
+        "status",
+        description="Check if the REST API server is up and running",
+    )
+    p_status.add_argument("--port", type=int, default=7480,
+                          help="Port to be checked.")
     p_status.set_defaults(func=status)
 
-    p_ops = subparsers.add_parser("recovery")
-    p_ops.add_argument("--server-name", required=True)
-    p_ops.add_argument("--operation-id", required=True)
+    p_ops = subparsers.add_parser(
+        "recovery",
+        description="Perform a 'barman recover' through the 'pg-backup-api'. "
+                    "Can only be run if a recover operation has been "
+                    "previously registered."
+    )
+    p_ops.add_argument("--server-name", required=True,
+                       help="Name of the Barman server to be recovered.")
+    p_ops.add_argument("--operation-id", required=True,
+                       help="ID of the operation in the 'pg-backup-api'.")
     p_ops.set_defaults(func=recovery_operation)
 
     args = p.parse_args()

--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -48,8 +48,7 @@ def diagnose():
             # Unknown server
             server_dict[server] = None
         else:
-            server_object = Server(conf)
-            server_dict[server] = server_object
+            server_dict[server] = Server(conf)
 
     # errors list with duplicate paths between servers
     errors_list = barman.__config__.servers_msg_list
@@ -101,8 +100,7 @@ def servers_operations_post(server_name, request):
         msg_404 = f"Server '{server_name}' does not exist"
         abort(404, description=msg_404)
 
-    server_object = Server(server)
-    backup_id = parse_backup_id(server_object, request_body["backup_id"])
+    backup_id = parse_backup_id(Server(server), request_body["backup_id"])
     if not backup_id:
         msg_404 = f"Backup '{backup_id}' does not exist"
         abort(404, description=msg_404)

--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -109,7 +109,7 @@ def servers_operations_post(server_name, request):
     operation = ServerOperation(server_name, operation_id=operation_id)
 
     try:
-        operation.write_jobs_files(request_body)
+        operation.create_job_file(request_body)
     except KeyError:
         msg_400 = "Make sure all options/arguments are met and try again"
         abort(400, description=msg_400)

--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -26,10 +26,12 @@ import barman
 from barman import diagnose as barman_diagnose, output
 from barman.server import Server
 
-from pg_backup_api.utils import load_barman_config, get_server_by_name, parse_backup_id
+from pg_backup_api.utils import (load_barman_config, get_server_by_name,
+                                 parse_backup_id)
 
 from pg_backup_api.run import app
-from pg_backup_api.server_operation import ServerOperation, ServerOperationConfigError
+from pg_backup_api.server_operation import (ServerOperation,
+                                            ServerOperationConfigError)
 
 
 @app.route("/diagnose", methods=["GET"])

--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -92,20 +92,20 @@ def servers_operation_id_get(server_name, operation_id):
 def servers_operations_post(server_name, request):
     request_body = request.get_json()
     if not request_body:
-        message_400 = f"Minimum barman options not met for server '{server_name}'"
-        abort(400, description=message_400)
+        msg_400 = f"Minimum barman options not met for server '{server_name}'"
+        abort(400, description=msg_400)
 
     server = get_server_by_name(server_name)
 
     if not server:
-        message_404 = f"Server '{server_name}' does not exist"
-        abort(404, description=message_404)
+        msg_404 = f"Server '{server_name}' does not exist"
+        abort(404, description=msg_404)
 
     server_object = Server(server)
     backup_id = parse_backup_id(server_object, request_body["backup_id"])
     if not backup_id:
-        message_404 = f"Backup '{backup_id}' does not exist"
-        abort(404, description=message_404)
+        msg_404 = f"Backup '{backup_id}' does not exist"
+        abort(404, description=msg_404)
 
     operation_id = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
     operation = ServerOperation(server_name, operation_id=operation_id)
@@ -113,10 +113,13 @@ def servers_operations_post(server_name, request):
     try:
         operation.write_jobs_files(request_body)
     except KeyError:
-        message_400 = "Make sure all options/arguments are met and try again"
-        abort(400, description=message_400)
+        msg_400 = "Make sure all options/arguments are met and try again"
+        abort(400, description=msg_400)
 
-    cmd = f"pg-backup-api recovery --server-name {server_name} --operation-id {operation_id}"
+    cmd = (
+        f"pg-backup-api recovery --server-name {server_name} "
+        f"--operation-id {operation_id}"
+    )
     subprocess.Popen(cmd.split())
     return {"operation_id": operation_id}
 

--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -92,21 +92,19 @@ def servers_operation_id_get(server_name, operation_id):
 def servers_operations_post(server_name, request):
     request_body = request.get_json()
     if not request_body:
-        message_400 = "Minimum barman options not met for server '{}'".format(
-            server_name
-        )
+        message_400 = f"Minimum barman options not met for server '{server_name}'"
         abort(400, description=message_400)
 
     server = get_server_by_name(server_name)
 
     if not server:
-        message_404 = "Server '{}' does not exist".format(server_name)
+        message_404 = f"Server '{server_name}' does not exist"
         abort(404, description=message_404)
 
     server_object = Server(server)
     backup_id = parse_backup_id(server_object, request_body["backup_id"])
     if not backup_id:
-        message_404 = "Backup '{}' does not exist".format(backup_id)
+        message_404 = f"Backup '{backup_id}' does not exist"
         abort(404, description=message_404)
 
     operation_id = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
@@ -118,9 +116,7 @@ def servers_operations_post(server_name, request):
         message_400 = "Make sure all options/arguments are met and try again"
         abort(400, description=message_400)
 
-    cmd = "pg-backup-api recovery --server-name {} --operation-id {}".format(
-        server_name, operation_id
-    )
+    cmd = f"pg-backup-api recovery --server-name {server_name} --operation-id {operation_id}"
     subprocess.Popen(cmd.split())
     return {"operation_id": operation_id}
 

--- a/pg_backup_api/pg_backup_api/run.py
+++ b/pg_backup_api/pg_backup_api/run.py
@@ -60,7 +60,8 @@ def status(args):
 
 def run_and_return_barman_recover(options, barman_args):
     cmd = "barman recover".split() + options + barman_args
-    process = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+    process = subprocess.Popen(cmd, stderr=subprocess.STDOUT,
+                               stdout=subprocess.PIPE)
     stdout, _ = process.communicate()
 
     return (stdout, process.returncode)
@@ -89,6 +90,7 @@ def recovery_operation(args):
     barman_args.append(content["destination_directory"])
 
     output, retcode = run_and_return_barman_recover(options, barman_args)
+    output = output.decode() if isinstance(output, bytes) else output
     success = True
     if retcode:
         success = False
@@ -96,6 +98,6 @@ def recovery_operation(args):
     end_time = server_ops.time_event_now()
     content["success"] = success
     content["end_time"] = end_time
-    content["output"] = output.decode() if isinstance(output, bytes) else output
+    content["output"] = output
 
     return (server_ops.create_output_file(content), success)

--- a/pg_backup_api/pg_backup_api/run.py
+++ b/pg_backup_api/pg_backup_api/run.py
@@ -51,7 +51,7 @@ def serve(args):
 def status(args):
     message = "OK"
     try:
-        requests.get("http://127.0.0.1:{args.port}/status".format(args=args))
+        requests.get(f"http://127.0.0.1:{args.port}/status")
     except ConnectionError:
         message = "The Postgres Backup API does not appear to be available."
 
@@ -73,7 +73,7 @@ def extract_options_from_file(jobfile_content):
     for option_name in API_CONFIG["supported_options"]:
         if option_name in available_keys:
             cmd_option = option_name.replace("_", "-")
-            options.append("--{}".format(cmd_option))
+            options.append(f"--{cmd_option}")
             options.append(jobfile_content[option_name])
     return options
 

--- a/pg_backup_api/pg_backup_api/server_operation.py
+++ b/pg_backup_api/pg_backup_api/server_operation.py
@@ -3,10 +3,9 @@ import json
 import logging
 import os
 import sys
-import tempfile
 
 from datetime import datetime
-from os.path import join, exists
+from os.path import join
 
 from pg_backup_api.utils import barman, load_barman_config, get_server_by_name
 
@@ -41,8 +40,9 @@ class Metadata(object):
 class ServerOperation(Metadata):
     def get_operations_list(self):
         jobs_list = []
-        if os.path.exists(self.jobs_basedir):
-            for job in [files for _, _, files in os.walk(self.jobs_basedir)][0]:
+        jobs_basedir = self.jobs_basedir
+        if os.path.exists(jobs_basedir):
+            for job in [files for _, _, files in os.walk(jobs_basedir)][0]:
                 if job.endswith(".json"):
                     operation_id, _ = job.split(".json")
                     jobs_list.append(operation_id)
@@ -128,7 +128,7 @@ def main(callback):
 
     try:
         log.info(callback())
-    except Exception(e):
+    except Exception as e:
         # TODO: we might behave differently depending upon the type here
         log.error(e)
         return -1

--- a/pg_backup_api/pg_backup_api/server_operation.py
+++ b/pg_backup_api/pg_backup_api/server_operation.py
@@ -32,9 +32,9 @@ class Metadata(object):
                 f"No barman config found for '{server_name}'."
             )
 
-        BARMAN_HOME = barman.__config__.barman_home
-        self.jobs_basedir = join(BARMAN_HOME, server_name, JOBS_DIR)
-        self.output_basedir = join(BARMAN_HOME, server_name, OUTPUT_DIR)
+        barman_home = barman.__config__.barman_home
+        self.jobs_basedir = join(barman_home, server_name, JOBS_DIR)
+        self.output_basedir = join(barman_home, server_name, OUTPUT_DIR)
 
 
 class ServerOperation(Metadata):

--- a/pg_backup_api/pg_backup_api/server_operation.py
+++ b/pg_backup_api/pg_backup_api/server_operation.py
@@ -29,7 +29,7 @@ class Metadata(object):
         self.server_config = get_server_by_name(server_name)
         if not self.server_config:
             raise ServerOperationConfigError(
-                "No barman config found for '{}'.".format(server_name)
+                f"No barman config found for '{server_name}'."
             )
 
         BARMAN_HOME = barman.__config__.barman_home
@@ -89,7 +89,7 @@ class ServerOperation(Metadata):
         if not self.operation_id:
             raise Exception("operation_id is required here")
 
-        file_name = "{}.json".format(self.operation_id)
+        file_name = f"{self.operation_id}.json"
         fpath = join(file_type, file_name)
         if os.path.exists(fpath):
             raise Exception("duplicated operation-id")
@@ -109,13 +109,13 @@ class ServerOperation(Metadata):
 
     def __files_path(self, basedir):
         if not os.path.exists(basedir):
-            msg = "Couldn't find a task for server '{}'".format(self.server_name)
+            msg = f"Couldn't find a task for server '{self.server_name}'"
             raise Exception(msg)
 
         if not self.operation_id:
             raise Exception("operation_id is required here")
 
-        file_name = "{}.json".format(self.operation_id)
+        file_name = f"{self.operation_id}.json"
         fpath = join(basedir, file_name)
         return fpath
 

--- a/pg_backup_api/pg_backup_api/server_operation.py
+++ b/pg_backup_api/pg_backup_api/server_operation.py
@@ -145,10 +145,27 @@ if __name__ == "__main__":
         "create-operation": "create_job_file",
         "get-operation": "get_status_by_operation_id",
     }
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--server-name", required=True)
-    parser.add_argument("--operation-id")
-    parser.add_argument("command", choices=operations_commands.keys())
+    parser = argparse.ArgumentParser(
+        description="Alternative to the REST API, so one can list, create and "
+                    "get information about jobs without a running REST API.",
+    )
+    parser.add_argument(
+        "--server-name", required=True,
+        help="Name of the Barman server related to the recovery "
+             "operation.",
+    )
+    parser.add_argument(
+        "--operation-id",
+        help="ID of the recovery operation, if you are trying to query an "
+             "existing operation."
+    )
+    parser.add_argument(
+        "command",
+        choices=operations_commands.keys(),
+        help="What we should do -- list recovery operations, create a new "
+             "recovery operation, or get info about a specific recovery "
+             "operation.",
+    )
 
     args = parser.parse_args()
     op = ServerOperation(args.server_name, args.operation_id)

--- a/pg_backup_api/pg_backup_api/server_operation.py
+++ b/pg_backup_api/pg_backup_api/server_operation.py
@@ -74,15 +74,17 @@ class ServerOperation(Metadata):
 
         return job_data
 
-    def write_jobs_files(self, general_options):
-        for directory in (self.jobs_basedir, self.output_basedir):
-            if not os.path.exists(directory):
-                os.makedirs(directory)
+    def create_job_file(self, general_options):
+        if not os.path.exists(self.jobs_basedir):
+            os.makedirs(self.jobs_basedir)
 
         job_data = self.copy_and_validate_options(general_options)
         self.__create_file(self.jobs_basedir, job_data)
 
     def create_output_file(self, content_file):
+        if not os.path.exists(self.output_basedir):
+            os.makedirs(self.output_basedir)
+
         self.__create_file(self.output_basedir, content_file)
 
     def __create_file(self, file_type, content):
@@ -140,7 +142,7 @@ if __name__ == "__main__":
 
     operations_commands = {
         "list-operations": "get_operations_list",
-        "create-operation": "write_jobs_files",
+        "create-operation": "create_job_file",
         "get-operation": "get_status_by_operation_id",
     }
     parser = argparse.ArgumentParser()

--- a/pg_backup_api/pg_backup_api/tests/test_serveroperation.py
+++ b/pg_backup_api/pg_backup_api/tests/test_serveroperation.py
@@ -50,7 +50,7 @@ def test_instance_methods(monkeypatch):
 
     obj = ServerOperation('arg')
     public_methods = ('get_operations_list', 'get_status_by_operation_id',
-                      'copy_and_validate_options', 'write_jobs_files',
+                      'copy_and_validate_options', 'create_job_file',
                       'create_output_file', 'get_job_file_content',
                       'get_output_file', 'get_job_file')
     for check in public_methods:

--- a/pg_backup_api/pg_backup_api/utils.py
+++ b/pg_backup_api/pg_backup_api/utils.py
@@ -50,12 +50,13 @@ def setup_logging_for_wsgi_server():
     """
     Configure logging.
     """
+    log_format = "[%(asctime)s] %(levelname)s:%(module)s: %(message)s"
     dictConfig(
         {
             "version": 1,
             "formatters": {
                 "default": {
-                    "format": "[%(asctime)s] %(levelname)s:%(module)s: %(message)s",
+                    "format": log_format,
                 }
             },
             "handlers": {
@@ -84,7 +85,7 @@ def parse_backup_id(server, backup_id):
         backup_id = server.get_last_backup_id()
     elif backup_id in ("oldest", "first"):
         backup_id = server.get_first_backup_id()
-    elif args.backup_id in ("last-failed"):
+    elif backup_id in ("last-failed"):
         backup_id = server.get_last_backup_id([BackupInfo.FAILED])
 
     return server.get_backup(backup_id)

--- a/pg_backup_api/pg_backup_api/utils.py
+++ b/pg_backup_api/pg_backup_api/utils.py
@@ -73,8 +73,7 @@ def setup_logging_for_wsgi_server():
 
 
 def get_server_by_name(server_name):
-    servers = barman.__config__.server_names()
-    for server in servers:
+    for server in barman.__config__.server_names():
         conf = barman.__config__.get_server(server)
         if server == server_name:
             return conf


### PR DESCRIPTION
The idea of this PR is to apply a few changes to the `pg-backup-api` code:

* Fix issues reported by `flake8`
* Use f-strings instead of `str.format`
* Get rid of placeholder variables that are used only once
* Rename variables that are named as if they were a module constant – `BARMAN_HOME`
* Have methods that perform a similar job to follow similar conventions in naming and behavior – `write_jobs_files` vs `create_output_file`
* Improve description and helper of argument parsers of `pg-backup-api`

References: BAR-91.
