### PR TITLE
Add a way of creating and executing "config switch" operations

### DIFF
--- a/pg_backup_api/pg_backup_api/__main__.py
+++ b/pg_backup_api/pg_backup_api/__main__.py
@@ -20,7 +20,8 @@
 import argparse
 import sys
 
-from pg_backup_api.run import serve, status, recovery_operation
+from pg_backup_api.run import (serve, status, recovery_operation,
+                               config_switch_operation)
 
 
 def main() -> None:
@@ -67,6 +68,19 @@ def main() -> None:
     p_ops.add_argument("--operation-id", required=True,
                        help="ID of the operation in the 'pg-backup-api'.")
     p_ops.set_defaults(func=recovery_operation)
+
+    p_ops = subparsers.add_parser(
+        "config-switch",
+        description="Perform a 'barman config switch' through the "
+                    "'pg-backup-api'. Can only be run if a config switch "
+                    "operation has been previously registered."
+    )
+    p_ops.add_argument("--server-name", required=True,
+                       help="Name of the Barman server which config should be "
+                            "switched.")
+    p_ops.add_argument("--operation-id", required=True,
+                       help="ID of the operation in the 'pg-backup-api'.")
+    p_ops.set_defaults(func=config_switch_operation)
 
     args = p.parse_args()
     if hasattr(args, "func") is False:

--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -156,7 +156,7 @@ def servers_operations_post(server_name: str,
     :param request: the flask request that has been received by the routing
         function.
 
-        Should contain a JSON body with a key ``type``, which identified the
+        Should contain a JSON body with a key ``type``, which identifies the
         type of the operation. The rest of the content depends on the type of
         operation being requested:
 
@@ -168,11 +168,10 @@ def servers_operations_post(server_name: str,
             * ``remote_ssh_command``: SSH command to connect to the target
               machine.
 
-        * ``config_switch`` -- TODO: update arguments:
+        * ``config_switch``:
 
-            * ``to``: some argument;
-            * ``be``: some other argument;
-            * ``defined``: some other argument.
+            * ``model_name``: the name of the model to be applied; or
+            * ``reset``: if you want to unapply a currently active model.
 
     :return: if *server_name* and the JSON body informed through the
         ``POST`` request are valid, return a JSON response containing a key
@@ -217,7 +216,6 @@ def servers_operations_post(server_name: str,
         operation = RecoveryOperation(server_name)
         cmd = f"pg-backup-api recovery --server-name {server_name}"
     elif op_type == OperationType.CONFIG_SWITCH:
-        # TODO: define the logic for performing a config switch operation
         operation = ConfigSwitchOperation(server_name)
         cmd = f"pg-backup-api config-switch --server-name {server_name}"
 

--- a/pg_backup_api/pg_backup_api/server_operation.py
+++ b/pg_backup_api/pg_backup_api/server_operation.py
@@ -19,8 +19,8 @@
 """
 Logic for performing operations through the pg-backup-api.
 
-:var DEFAULT_OP_TYPE: default operation to be performed (``recovery``), if none
-is specified.
+:data DEFAULT_OP_TYPE: default operation to be performed (``recovery``), if
+none is specified.
 """
 from abc import abstractmethod
 import argparse
@@ -48,6 +48,7 @@ log = logging.getLogger()
 class OperationType(Enum):
     """Describe operations that can be performed through pg-backup-api."""
     RECOVERY = "recovery"
+    CONFIG_SWITCH = "config_switch"
 
 
 DEFAULT_OP_TYPE = OperationType.RECOVERY
@@ -74,9 +75,9 @@ class OperationServer:
 
     :ivar name: name of the Barman server.
     :ivar config: Barman configuration of the Barman server.
-    :ivar jobs_basedir: directory where to save files of recovery operations
-        that have been created for this Barman server.
-    :ivar output_basedir: directory where to save files with output of recovery
+    :ivar jobs_basedir: directory where to save files of operations that have
+        been created for this Barman server.
+    :ivar output_basedir: directory where to save files with output of
         operations that have been finished for this Barman server -- both for
         failed and successful executions.
     """
@@ -641,6 +642,103 @@ class RecoveryOperation(Operation):
         return self._run_subprocess(cmd)
 
 
+class ConfigSwitchOperation(Operation):
+    """
+    Contain information and logic to process a config switch operation.
+
+    :cvar REQUIRED_ARGUMENTS: required arguments when creating a config switch
+        operation.
+    :cvar TYPE: enum type of this operation.
+    """
+
+    # TODO: define which arguments will be required
+    REQUIRED_ARGUMENTS = ("to", "be", "defined",)
+    TYPE = OperationType.CONFIG_SWITCH
+
+    @classmethod
+    def _validate_job_content(cls, content: Dict[str, Any]) -> None:
+        """
+        Validate the content of the job file before creating it.
+
+        :param content: Python dictionary representing the JSON content of the
+            job file.
+
+        :raises:
+            :exc:`MalformedContent`: if the set of options in *content* is
+                either missing required keys.
+        """
+        required_args: Set[str] = set(cls.REQUIRED_ARGUMENTS)
+        missing_args = required_args - set(content.keys())
+
+        if missing_args:
+            msg = (
+                "Missing required arguments: "
+                f"{', '.join(sorted(missing_args))}"
+            )
+            raise MalformedContent(msg)
+
+    def write_job_file(self, content: Dict[str, Any]) -> None:
+        """
+        Write the job file with *content*.
+
+        .. note::
+            See :meth:`Operation.write_job_file` for more details.
+
+        :param content: Python dictionary representing the JSON content of the
+            job file. Besides what is contained in *content*, this method adds
+            the following keys:
+
+            * ``operation_type``: ``config_switch``;
+            * ``start_time``: current timestamp.
+        """
+        content["operation_type"] = self.TYPE.value
+        content["start_time"] = self.time_event_now()
+        self._validate_job_content(content)
+        super().write_job_file(content)
+
+    def _get_args(self) -> List[str]:
+        """
+        Get arguments for running ``barman config switch`` command.
+
+        :return: list of arguments for ``barman config switch`` command.
+        """
+        job_content = self.read_job_file()
+
+        # TODO: define which arguments will be used
+        to = job_content.get("to")
+        be = job_content.get("be")
+        defined = job_content.get("defined")
+
+        if TYPE_CHECKING:  # pragma: no cover
+            assert isinstance(to, str)
+            assert isinstance(be, str)
+            assert isinstance(defined, str)
+
+        return [
+            self.server.name,
+            to,
+            be,
+            defined,
+        ]
+
+    def _run_logic(self) -> \
+            Tuple[Union[str, bytearray, memoryview], Union[int, Any]]:
+        """
+        Logic to be ran when executing the config switch operation.
+
+        Run ``barman config switch`` command with the configured arguments.
+
+        Will be called when running :meth:`Operation.run`.
+
+        :return: a tuple consisting of:
+
+            * ``stdout``/``stderr`` of ``barman config switch``;
+            * exit code of ``barman config switch``.
+        """
+        cmd = ["barman", "config", "switch"] + self._get_args()
+        return self._run_subprocess(cmd)
+
+
 def main(callback: Callable[..., Any], *args: Tuple[Any, ...]) -> int:
     """
     Execute *callback* with *args* and log its output as an ``INFO`` message.
@@ -674,12 +772,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--server-name", required=True,
-        help="Name of the Barman server related to the recovery "
-             "operation.",
+        help="Name of the Barman server related to the operation.",
     )
     parser.add_argument(
         "--operation-type",
         choices=[op_type.value for op_type in OperationType],
+        default=OperationType.RECOVERY.value,
         help="Type of the operation. Optional for 'list-operations' command. "
              "Defaults to 'recovery' for 'get-operation' command."
     )
@@ -691,8 +789,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "command",
         choices=["list-operations", "get-operation"],
-        help="What we should do -- list recovery operations, or get info "
-             "about a specific operation.",
+        help="What we should do -- list operations, or get info about a "
+             "specific operation.",
     )
 
     args = parser.parse_args()

--- a/pg_backup_api/pg_backup_api/tests/test_main.py
+++ b/pg_backup_api/pg_backup_api/tests/test_main.py
@@ -28,10 +28,10 @@ from pg_backup_api.__main__ import main
 
 _HELP_OUTPUT = {
     "pg-backup-api --help": dedent("""\
-        usage: pg-backup-api [-h] {serve,status,recovery} ...
+        usage: pg-backup-api [-h] {serve,status,recovery,config-switch} ...
 
         positional arguments:
-          {serve,status,recovery}
+          {serve,status,recovery,config-switch}
 
         optional arguments:
           -h, --help            show this help message and exit
@@ -75,12 +75,29 @@ _HELP_OUTPUT = {
                                 ID of the operation in the 'pg-backup-api'.
 \
     """),  # noqa: E501
+    "pg-backup-api config-switch --help": dedent("""\
+        usage: pg-backup-api config-switch [-h] --server-name SERVER_NAME
+                                           --operation-id OPERATION_ID
+
+        Perform a 'barman config switch' through the 'pg-backup-api'. Can only be run
+        if a config switch operation has been previously registered.
+
+        optional arguments:
+          -h, --help            show this help message and exit
+          --server-name SERVER_NAME
+                                Name of the Barman server which config should be
+                                switched.
+          --operation-id OPERATION_ID
+                                ID of the operation in the 'pg-backup-api'.
+\
+    """),  # noqa: E501
 }
 
 _COMMAND_FUNC = {
     "pg-backup-api serve": "serve",
     "pg-backup-api status": "status",
     "pg-backup-api recovery --server-name SOME_SERVER --operation-id SOME_OP_ID": "recovery_operation",  # noqa: E501
+    "pg-backup-api config-switch --server-name SOME_SERVER --operation-id SOME_OP_ID": "config_switch_operation",  # noqa: E501
 }
 
 

--- a/pg_backup_api/pg_backup_api/tests/test_run.py
+++ b/pg_backup_api/pg_backup_api/tests/test_run.py
@@ -24,7 +24,8 @@ from unittest.mock import MagicMock, patch, call
 
 import pytest
 
-from pg_backup_api.run import serve, status, recovery_operation
+from pg_backup_api.run import (serve, status, recovery_operation,
+                               config_switch_operation)
 
 
 @pytest.mark.parametrize("port", [7480, 7481])
@@ -108,6 +109,44 @@ def test_recovery_operation(mock_rec_op, server_name, operation_id, rc):
 
     mock_rec_op.assert_called_once_with(server_name, operation_id)
     mock_rec_op.return_value.run.assert_called_once_with()
+    mock_time_event.assert_called_once_with()
+    mock_read_job.assert_called_once_with()
+
+    # Make sure the expected content was added to `read_job_file` output before
+    # writing it to the output file.
+    assert len(mock_read_job.return_value.__setitem__.mock_calls) == 3
+    mock_read_job.return_value.__setitem__.assert_has_calls([
+        call('success', rc == 0),
+        call('end_time', mock_time_event.return_value),
+        call('output', "SOME_OUTPUT"),
+    ])
+
+    mock_write_output.assert_called_once_with(mock_read_job.return_value)
+
+
+@pytest.mark.parametrize("server_name", ["SERVER_1", "SERVER_2"])
+@pytest.mark.parametrize("operation_id", ["OPERATION_1", "OPERATION_2"])
+@pytest.mark.parametrize("rc", [0, 1])
+@patch("pg_backup_api.run.ConfigSwitchOperation")
+def test_config_switch_operation(mock_cs_op, server_name, operation_id, rc):
+    """Test :func:`config_switch_operation`.
+
+    Ensure the operation is created and executed, and that the expected values
+    are returned depending on the return code.
+    """
+    args = argparse.Namespace(server_name=server_name,
+                              operation_id=operation_id)
+
+    mock_cs_op.return_value.run.return_value = ("SOME_OUTPUT", rc)
+    mock_write_output = mock_cs_op.return_value.write_output_file
+    mock_time_event = mock_cs_op.return_value.time_event_now
+    mock_read_job = mock_cs_op.return_value.read_job_file
+
+    assert config_switch_operation(args) == (mock_write_output.return_value,
+                                             rc == 0)
+
+    mock_cs_op.assert_called_once_with(server_name, operation_id)
+    mock_cs_op.return_value.run.assert_called_once_with()
     mock_time_event.assert_called_once_with()
     mock_read_job.assert_called_once_with()
 


### PR DESCRIPTION
Through this PR we expose an operation in the REST API for performing `barman config-switch` command remotely. The following changes have been applied:

* Create a ``ConfigSwitchOperation`` class, which takes care of validating the arguments for a config switch operation, and also of running such operation;
* Modify `servers_operations_post` Flask end point so it is able to receive POST requests both for creating a recovery operation or a config switch operation;
* Create a new command ``pg-backup-api config-switch``, which is used by the API in order to run the config switch on Barman;
* Create a function ``config_switch_operation``, which is used by ``pg-backup-api config-switch`` command;
* Create a helper function ``_run_operation``, which is used both by ``recovery_operation`` and ``config_switch_operation`` functions. They both have a very similar logic, so that helper function executes the common code paths.

The new API endpoint is able to handle both an "apply model" or a "reset model" through `barman config-switch` command.

References: BAR-125.