### PR TITLE
Add workflow for performing tests on pushes and PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,135 @@
+name: Tests
+
+on:
+  pull_request:
+
+  push:
+    branches:
+    - main
+
+  workflow_dispatch:
+    inputs:
+      source-ref:
+        description: Source code branch/ref name
+        default: main
+        required: true
+        type: string
+
+env:
+  SOURCE_REF: ${{ inputs.source-ref || github.ref }}
+  WORKING_DIRECTORY: ./pg_backup_api
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ env.SOURCE_REF }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+
+    - name: Install tox
+      run:
+        pip install tox
+
+    - name: Run linter
+      working-directory: ${{ env.WORKING_DIRECTORY }}
+      run:
+        tox -e lint
+
+  dependency_checking:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ env.SOURCE_REF }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+
+    - name: Install tox
+      run:
+        pip install tox
+
+    - name: Run dependency checker
+      working-directory: ${{ env.WORKING_DIRECTORY }}
+      run:
+        tox -e dep
+
+  unit_tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        python-version:
+        - '3.7'
+        - '3.8'
+        - '3.9'
+        - '3.10'
+        - '3.11'
+
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ env.SOURCE_REF }}
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install tox
+      run:
+        pip install tox
+
+    - name: Run unit tests
+      working-directory: ${{ env.WORKING_DIRECTORY }}
+      run:
+        tox -m test
+
+  static_type_checking:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        python-version:
+        - '3.7'
+        - '3.8'
+        - '3.9'
+        - '3.10'
+        - '3.11'
+
+    steps:
+      - name: Checkout the source code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.SOURCE_REF }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install tox
+        run:
+          pip install tox
+
+      - name: Run static type checks
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run:
+          tox -m type

--- a/README.md
+++ b/README.md
@@ -117,12 +117,61 @@ The command returns `"OK"` if the app is up and running.
 
 ## Testing
 
-You can run unit tests through `pytest`:
+The repository contains a `tox.ini` file which declares a set of test
+environments that are available.
+
+In the following sub-sections you will find more information about how to
+manually run each of the tests. All of them assume you are inside the
+`pg_backup_api` folder which can be found in the repository root directory.
+
+**Note:** install `tox` Python module if you don't have it yet in your
+environment.
+
+### Lint
+
+You can run the `flake8` linter over the code by running this command:
 
 ```bash
-cd pg-backup-api/pg_backup_api
-python3 -m pytest
+tox -e lint
 ```
 
-**Note:** install `pytest` Python module if you don't have it yet in your
+It will check the source code, tests, and `setup.py`.
+
+### Dependency checking
+
+You can run the dependency checker `pipdeptree` by running this command:
+
+```bash
+tox -e dep
+```
+
+It will print the tree of Python modules used by `pg-backup-api`, which can be
+helpful in solving conflicts..
+
+### Unit tests
+
+You can run unit tests by running this command:
+
+```bash
+tox -m test
+```
+
+It will run unit tests using `pytest` module and `pytest-cov` plugin for
+coverage report.
+
+**Note:** the command will take care of running the tests using all Python
+versions which are supported by `pg-backup-api` and that are available in your
 environment.
+
+### Static type checking
+
+You can run the static type checker `pyright` over the source code by running
+this command:
+
+```bash
+tox -m type
+```
+
+**Note:** the command will take care of running the static type checker using
+all Python versions which are supported by `pg-backup-api` and that are
+available in your environment.

--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -40,6 +40,8 @@ from pg_backup_api.server_operation import (OperationServer,
 
 if TYPE_CHECKING:  # pragma: no cover
     from flask import Request, Response
+    from barman.config import Config as BarmanConfig
+    from pg_backup_api.server_operation import Operation
 
 
 @app.route("/diagnose", methods=["GET"])
@@ -53,11 +55,15 @@ def diagnose() -> 'Response':
     """
     # Reload the barman config so that any changes are picked up
     load_barman_config()
+
+    if TYPE_CHECKING:  # pragma: no cover
+        assert isinstance(barman.__config__, BarmanConfig)
+
     # Get every server (both inactive and temporarily disabled)
     servers = barman.__config__.server_names()
 
     server_dict = {}
-    for server in servers:
+    for server in servers:  # pyright: ignore
         conf = barman.__config__.get_server(server)
         if conf is None:
             # Unknown server
@@ -213,6 +219,9 @@ def servers_operations_post(server_name: str,
             f"--operation-id {operation.id}"
         )
         subprocess.Popen(cmd.split())
+
+    if TYPE_CHECKING:  # pragma: no cover
+        assert isinstance(operation, Operation)
 
     return {"operation_id": operation.id}
 

--- a/pg_backup_api/pg_backup_api/server_operation.py
+++ b/pg_backup_api/pg_backup_api/server_operation.py
@@ -30,7 +30,7 @@ import logging
 import os
 import subprocess
 import sys
-from typing import (Any, Callable, Dict, List, Optional, Set, Tuple,
+from typing import (Any, Callable, Dict, List, Optional, Set, Tuple, Union,
                     TYPE_CHECKING)
 
 from datetime import datetime
@@ -494,7 +494,8 @@ class Operation:
         return self.server.get_operation_status(self.id)
 
     @staticmethod
-    def _run_subprocess(cmd: List[str]) -> Tuple[Optional[str], int]:
+    def _run_subprocess(cmd: List[str]) -> \
+            Tuple[Union[str, bytearray, memoryview], Union[int, Any]]:
         """
         Run *cmd* as a subprocess.
 
@@ -512,7 +513,8 @@ class Operation:
         return stdout, process.returncode
 
     @abstractmethod
-    def _run_logic(self) -> Tuple[Optional[str], int]:
+    def _run_logic(self) -> \
+            Tuple[Union[str, bytearray, memoryview], Union[int, Any]]:
         """
         Logic to be ran when executing the operation.
 
@@ -526,7 +528,7 @@ class Operation:
         """
         pass
 
-    def run(self) -> Tuple[Optional[str], int]:
+    def run(self) -> Tuple[Union[str, bytearray, memoryview], Union[int, Any]]:
         """
         Run the operation.
 
@@ -621,7 +623,8 @@ class RecoveryOperation(Operation):
             remote_ssh_command,
         ]
 
-    def _run_logic(self) -> Tuple[Optional[str], int]:
+    def _run_logic(self) -> \
+            Tuple[Union[str, bytearray, memoryview], Union[int, Any]]:
         """
         Logic to be ran when executing the recovery operation.
 

--- a/pg_backup_api/pyrightconfig.json
+++ b/pg_backup_api/pyrightconfig.json
@@ -1,0 +1,9 @@
+{
+    "include": [
+      "pg_backup_api"
+    ],
+    
+    "exclude": [
+      "pg_backup_api/tests"
+    ],
+}

--- a/pg_backup_api/requirements-test.txt
+++ b/pg_backup_api/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+pytest-html

--- a/pg_backup_api/setup.py
+++ b/pg_backup_api/setup.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Postgres Backup API.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 from setuptools import setup, find_packages
 
 NAME = "pg-backup-api"
@@ -31,7 +30,8 @@ with open("./version.txt", "r") as f:
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["barman>=2.19,<4.0.0", "Flask>=0.10.1,<3.0.0", "requests>=2.0.0,<3.0.0"]
+REQUIRES = ["barman>=2.19,<4.0.0", "Flask>=0.10.1,<3.0.0",
+            "requests>=2.0.0,<3.0.0"]
 
 setup(
     name=NAME,
@@ -45,7 +45,9 @@ setup(
     install_requires=REQUIRES,
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    entry_points={"console_scripts": ["pg-backup-api=pg_backup_api.__main__:main"]},
+    entry_points={
+        "console_scripts": ["pg-backup-api=pg_backup_api.__main__:main"],
+    },
     license="GPL-3.0",
     long_description="""\
     A server that provides an HTTP API to interact with Postgres backups

--- a/pg_backup_api/tox.ini
+++ b/pg_backup_api/tox.ini
@@ -1,0 +1,92 @@
+[common]
+python_matrix = {37,38,39,310,311}
+platforms =
+    lin: linux
+    mac: darwin
+    win: win32
+
+[tox]
+min_version = 4.0
+requires =
+    tox>4
+env_list =
+    dep
+    lint
+    py{[common]python_matrix}-type-{lin,mac,win}
+    py{[common]python_matrix}-test-{lin,mac,win}
+skipsdist = True
+toxworkdir = {env:TOX_WORK_DIR:.tox}
+skip_missing_interpreters = True
+
+[testenv]
+setenv =
+    PYTHONDONTWRITEBYTECODE = 1
+    mac: OPEN_CMD = {env:OPEN_CMD:open}
+    lin: OPEN_CMD = {env:OPEN_CMD:xdg-open}
+passenv =
+    BROWSER
+    DISPLAY
+
+[testenv:lint]
+description = Lint code with flake8
+commands = flake8 {posargs:pg_backup_api setup.py}
+deps =
+    flake8
+
+[testenv:py{37,38,39,310,311}-test-{lin,win,mac}]
+description = Run unit tests with pytest
+labels =
+    test
+commands_pre =
+    - {tty:rm -f "{toxworkdir}{/}cov_report_{env_name}_html{/}index.html":true}
+    - {tty:rm -f "{toxworkdir}{/}pytest_report_{env_name}.html":true}
+commands =
+    pytest \
+    -p no:cacheprovider \
+    -vv \
+    --capture=no \
+    --cov=pg_backup_api \
+    --cov-report=term-missing \
+    --cov-append \
+    {tty::--cov-report="xml\:{toxworkdir}{/}cov_report.{env_name}.xml"} \
+    {tty:--cov-report="html\:{toxworkdir}{/}cov_report_{env_name}_html":} \
+    {tty:--html="{toxworkdir}{/}pytest_report_{env_name}.html":} \
+    {posargs:pg_backup_api}
+commands_post =
+    - {tty:{env:OPEN_CMD} "{toxworkdir}{/}cov_report_{env_name}_html{/}index.html":true}
+    - {tty:{env:OPEN_CMD} "{toxworkdir}{/}pytest_report_{env_name}.html":true}
+deps =
+    -r requirements.txt
+    -r requirements-test.txt
+platform =
+    {[common]platforms}
+allowlist_externals =
+    rm
+    true
+    {env:OPEN_CMD}
+
+[testenv:dep]
+description = Check package dependency problems
+commands = pipdeptree -w fail
+deps =
+    -r requirements.txt
+    pipdeptree
+
+[testenv:py{37,38,39,310,311}-type-{lin,mac,win}]
+description = Run static type checking with pyright
+labels =
+    type
+deps =
+    -r requirements.txt
+    pyright
+commands = pyright --venvpath {toxworkdir}{/}{envname} {posargs:pg_backup_api}
+platform =
+    {[common]platforms}
+
+[flake8]
+max-line-length = 79
+
+[coverage:run]
+omit =
+    pg_backup_api/app.py
+    pg_backup_api/tests/*


### PR DESCRIPTION
This PR adds a `tox.ini` file to the repository. It exposes a
few different test environments which can be used by the developer
for:

* Linting the code
* Checking Python modules dependencies
* Running unit tests with coverage report
* Running a static type checker

Instructions on how to use `tox` have been added to the `README.md`
file.

These facilities exposed by the implemented `tox.ini` file are used
by the `tests.yml` workflow which is also introduced by this PR. It is
responsible for running all the tests which are exposed by `tox.ini`

As part of this PR we also applied a few fixes which were reported by
the workflow runs:

* Issues reported by `flake8` in `setup.py`
* Issues reported by `pyright` in `server_operation.py`, `utils.py`,
  and `utility_controller.py`
* Issues on unit test `test_main_helper`: it was failing because of a
  difference between the terminal size of runners and our laptops
* Issues on unit test `test_server_operation_post_not_json` when
  ran through GitHub Actions with Python 3.7 + Flask 2.2.5. That
  combination caused Flask to return `400 Bad Request` instead of
  `415 Unsupported Media Type`, which is returned by other
  combinations

References: BAR-133.