### PR TITLE
Add support for remote `barman config-update` execution

### DIFF
--- a/pg_backup_api/pg_backup_api/__main__.py
+++ b/pg_backup_api/pg_backup_api/__main__.py
@@ -21,7 +21,8 @@ import argparse
 import sys
 
 from pg_backup_api.run import (serve, status, recovery_operation,
-                               config_switch_operation, config_update_operation)
+                               config_switch_operation,
+                               config_update_operation)
 
 
 def main() -> None:

--- a/pg_backup_api/pg_backup_api/__main__.py
+++ b/pg_backup_api/pg_backup_api/__main__.py
@@ -21,7 +21,7 @@ import argparse
 import sys
 
 from pg_backup_api.run import (serve, status, recovery_operation,
-                               config_switch_operation, config_model_operation)
+                               config_switch_operation, config_update_operation)
 
 
 def main() -> None:
@@ -83,14 +83,14 @@ def main() -> None:
     p_ops.set_defaults(func=config_switch_operation)
 
     p_ops = subparsers.add_parser(
-        "config-model",
-        description="Perform a 'barman config-model' through the "
-                    "'pg-backup-api'. Can only be run if a config model "
+        "config-update",
+        description="Perform a 'barman config-update' through the "
+                    "'pg-backup-api'. Can only be run if a config-update "
                     "operation has been previously registered."
     )
     p_ops.add_argument("--operation-id", required=True,
                        help="ID of the operation in the 'pg-backup-api'.")
-    p_ops.set_defaults(func=config_model_operation)
+    p_ops.set_defaults(func=config_update_operation)
 
     args = p.parse_args()
     if hasattr(args, "func") is False:

--- a/pg_backup_api/pg_backup_api/__main__.py
+++ b/pg_backup_api/pg_backup_api/__main__.py
@@ -21,7 +21,7 @@ import argparse
 import sys
 
 from pg_backup_api.run import (serve, status, recovery_operation,
-                               config_switch_operation)
+                               config_switch_operation, config_model_operation)
 
 
 def main() -> None:
@@ -81,6 +81,16 @@ def main() -> None:
     p_ops.add_argument("--operation-id", required=True,
                        help="ID of the operation in the 'pg-backup-api'.")
     p_ops.set_defaults(func=config_switch_operation)
+
+    p_ops = subparsers.add_parser(
+        "config-model",
+        description="Perform a 'barman config-model' through the "
+                    "'pg-backup-api'. Can only be run if a config model "
+                    "operation has been previously registered."
+    )
+    p_ops.add_argument("--operation-id", required=True,
+                       help="ID of the operation in the 'pg-backup-api'.")
+    p_ops.set_defaults(func=config_model_operation)
 
     args = p.parse_args()
     if hasattr(args, "func") is False:

--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -37,7 +37,7 @@ from pg_backup_api.server_operation import (OperationServer,
                                             DEFAULT_OP_TYPE,
                                             RecoveryOperation,
                                             ConfigSwitchOperation,
-                                            ConfigModelOperation,
+                                            ConfigUpdateOperation,
                                             MalformedContent)
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -325,11 +325,10 @@ def instance_operations_post(request: 'Request') -> Dict[str, str]:
         type of the operation. The rest of the content depends on the type of
         operation being requested:
 
-        * ``config_model``:
+        * ``config_update``:
 
-            * ``todo_to``: to value;
-            * ``todo_be``: be value;
-            * ``todo_defined``: defined value.
+            * ``changes``: an array of dictionaries to be used in
+              ``barman config-update``
 
     :return: if the JSON body informed through the ``POST`` request is valid,
         return a JSON response containing a key ``operation_id`` with the ID of
@@ -351,9 +350,9 @@ def instance_operations_post(request: 'Request') -> Dict[str, str]:
     cmd = None
     op_type = OperationType(request_body.get("type"))
 
-    if op_type == OperationType.CONFIG_MODEL:
-        operation = ConfigModelOperation()
-        cmd = "pg-backup-api config-model"
+    if op_type == OperationType.CONFIG_UPDATE:
+        operation = ConfigUpdateOperation(None)
+        cmd = "pg-backup-api config-update"
 
     if TYPE_CHECKING:  # pragma: no cover
         assert isinstance(operation, Operation)

--- a/pg_backup_api/pg_backup_api/logic/utility_controller.py
+++ b/pg_backup_api/pg_backup_api/logic/utility_controller.py
@@ -19,7 +19,7 @@
 """Define the Flask endpoints of the pg-backup-api REST API server."""
 import json
 import subprocess
-from typing import Any, Dict, Tuple, Union, TYPE_CHECKING
+from typing import Any, Dict, Optional, Tuple, Union, TYPE_CHECKING
 
 from flask import abort, jsonify, request
 
@@ -112,16 +112,13 @@ def resource_not_found(error: Any) -> Tuple['Response', int]:
     return jsonify(error=str(error)), 404
 
 
-@app.route("/servers/<server_name>/operations/<operation_id>")
-def servers_operation_id_get(server_name: str, operation_id: str) \
+def _operation_id_get(server_name: Optional[str], operation_id: str) \
         -> 'Response':
     """
-    ``GET`` request to ``/servers/*server_name*/operations/*operation_id*``.
+    Get status of an operation with ID *operation_id*.
 
-    Get status of an operation with ID *operation_id* for Barman server named
-    *server_name*.
-
-    :param server_name: name of the Barman server related to the operation.
+    :param server_name: name of the Barman server related to the operation, if
+        it's a server operation, ``None`` if it's an instance operation.
     :param operation_id: ID of the operation previously created through
         pg-backup-api.
     :return: if *server_name* and *operation_id* are valid, return a JSON
@@ -144,6 +141,37 @@ def servers_operation_id_get(server_name: str, operation_id: str) \
         abort(404, description=str(e))
     except Exception:
         abort(404, description="Resource not found")
+
+
+@app.route("/servers/<server_name>/operations/<operation_id>")
+def servers_operation_id_get(server_name: str, operation_id: str) \
+        -> 'Response':
+    """
+    ``GET`` request to ``/servers/*server_name*/operations/*operation_id*``.
+
+    Get status of an operation with ID *operation_id* for Barman server named
+    *server_name*.
+
+    :param server_name: name of the Barman server related to the operation.
+    :param operation_id: ID of the operation previously created through
+        pg-backup-api.
+    :return: see :func:`_operation_id_get` for details.
+    """
+    return _operation_id_get(server_name, operation_id)
+
+
+@app.route("/operations/<operation_id>")
+def instance_operation_id_get(operation_id: str) -> 'Response':
+    """
+    ``GET`` request to ``/operations/*operation_id*``.
+
+    Get status of an operation with ID *operation_id* for the Barman instance.
+
+    :param operation_id: ID of the operation previously created through
+        pg-backup-api.
+    :return: see :func:`_operation_id_get` for details.
+    """
+    return _operation_id_get(None, operation_id)
 
 
 def servers_operations_post(server_name: str,
@@ -235,6 +263,26 @@ def servers_operations_post(server_name: str,
     return {"operation_id": operation.id}
 
 
+def _operations_get(server_name: Optional[str]) \
+        -> Union[Tuple['Response', int], 'Response']:
+    """
+    Get a list of operations for a Barman server or instance.
+
+    :param server_name: name of the Barman server to fetch operations from, or
+        ``None`` for instance operations.
+
+    :return: a JSON response with ``operations`` key containing a list of
+        operations for a Barman server or instance. Each item in the list
+        contains the operation ID and the operation type.
+    """
+    try:
+        operation = OperationServer(server_name)
+        available_operations = {"operations": operation.get_operations_list()}
+        return jsonify(available_operations)
+    except OperationServerConfigError as e:
+        abort(404, description=str(e))
+
+
 @app.route("/servers/<server_name>/operations", methods=("GET", "POST"))
 def server_operation(server_name: str) \
         -> Union[Tuple['Response', int], 'Response']:
@@ -262,9 +310,60 @@ def server_operation(server_name: str) \
     if request.method == "POST":
         return jsonify(servers_operations_post(server_name, request)), 202
 
-    try:
-        operation = OperationServer(server_name)
-        available_operations = {"operations": operation.get_operations_list()}
-        return jsonify(available_operations)
-    except OperationServerConfigError as e:
-        abort(404, description=str(e))
+    return _operations_get(server_name)
+
+
+def instance_operations_post(request: 'Request') -> Dict[str, str]:
+    """
+    Handle ``POST`` request to ``/operations``.
+
+    :param request: the flask request that has been received by the routing
+        function.
+
+        Should contain a JSON body with a key ``type``, which identifies the
+        type of the operation. The rest of the content depends on the type of
+        operation being requested.
+
+    :return: if the JSON body informed through the ``POST`` request is valid,
+        return a JSON response containing a key ``operation_id`` with the ID of
+        the operation that has been created.
+
+        Otherwise, if any issue is identified, return a response with either of
+        the following statuses and the relevant error message:
+
+        * ``400``: if any required option is missing in the JSON request body.
+        * ``404``: if any value in the JSON request body is invalid.
+    """
+    request_body = request.get_json()
+
+    if not request_body:
+        msg_400 = "Minimum barman options not met for instance operation"
+        abort(400, description=msg_400)
+
+    return {"operation_id": "DUMMY"}
+
+
+@app.route("/operations", methods=("GET", "POST"))
+def instance_operation() -> Union[Tuple['Response', int], 'Response']:
+    """
+    Handle ``GET``/``POST`` request to ``/operations``.
+
+    Get a list of operations for the Barman instance, if a ``GET`` request, or
+    create a new operation for the instance, if a ``POST`` request.
+
+    :return: the returned response varies:
+
+        * If a successful ``GET`` request, then return a JSON response with
+          ``operations`` key containing a list of operations for the Barman
+          instance. Each item in the list contain the operation ID and the
+          operation type;
+        * If a successful ``POST`` request, then return a JSON response with
+          HTTP status ``202`` containing an ``operation_id`` key with the ID
+          of the operation that has been created for the Barman instance;
+        * If any issue is faced when processing the request, return an HTTP
+          ``400`` or ``404`` response with the relevant error message.
+    """
+    if request.method == "POST":
+        return jsonify(instance_operations_post(request)), 202
+
+    return _operations_get(None)

--- a/pg_backup_api/pg_backup_api/run.py
+++ b/pg_backup_api/pg_backup_api/run.py
@@ -30,7 +30,8 @@ from barman import output
 
 from pg_backup_api.utils import create_app, load_barman_config
 from pg_backup_api.server_operation import (RecoveryOperation,
-                                            ConfigSwitchOperation)
+                                            ConfigSwitchOperation,
+                                            ConfigModelOperation)
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -153,3 +154,21 @@ def config_switch_operation(args: 'argparse.Namespace') -> Tuple[None, bool]:
     """
     return _run_operation(ConfigSwitchOperation(args.server_name,
                                                 args.operation_id))
+
+
+def config_model_operation(args: 'argparse.Namespace') -> Tuple[None, bool]:
+    """
+    Perform a ``barman config-model`` through the pg-backup-api.
+
+    .. note::
+        See :func:`_run_operation` for more details.
+
+    :param args: command-line arguments for ``pg-backup-api config-model``
+        command. Contains the operation ID to be run.
+    :return: a tuple consisting of two items:
+
+        * ``None`` -- output of :meth:`ConfigModelOperation.write_output_file`
+        * ``True`` if ``barman config-model`` was successful, ``False``
+            otherwise.
+    """
+    return _run_operation(ConfigModelOperation(args.operation_id))

--- a/pg_backup_api/pg_backup_api/run.py
+++ b/pg_backup_api/pg_backup_api/run.py
@@ -31,7 +31,7 @@ from barman import output
 from pg_backup_api.utils import create_app, load_barman_config
 from pg_backup_api.server_operation import (RecoveryOperation,
                                             ConfigSwitchOperation,
-                                            ConfigModelOperation)
+                                            ConfigUpdateOperation)
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -156,19 +156,19 @@ def config_switch_operation(args: 'argparse.Namespace') -> Tuple[None, bool]:
                                                 args.operation_id))
 
 
-def config_model_operation(args: 'argparse.Namespace') -> Tuple[None, bool]:
+def config_update_operation(args: 'argparse.Namespace') -> Tuple[None, bool]:
     """
-    Perform a ``barman config-model`` through the pg-backup-api.
+    Perform a ``barman config-update`` through the pg-backup-api.
 
     .. note::
         See :func:`_run_operation` for more details.
 
-    :param args: command-line arguments for ``pg-backup-api config-model``
+    :param args: command-line arguments for ``pg-backup-api config-update``
         command. Contains the operation ID to be run.
     :return: a tuple consisting of two items:
 
-        * ``None`` -- output of :meth:`ConfigModelOperation.write_output_file`
-        * ``True`` if ``barman config-model`` was successful, ``False``
+        * ``None`` -- output of :meth:`ConfigUpdateOperation.write_output_file`
+        * ``True`` if ``barman config-update`` was successful, ``False``
             otherwise.
     """
-    return _run_operation(ConfigModelOperation(args.operation_id))
+    return _run_operation(ConfigUpdateOperation(None, args.operation_id))

--- a/pg_backup_api/pg_backup_api/server_operation.py
+++ b/pg_backup_api/pg_backup_api/server_operation.py
@@ -626,6 +626,7 @@ class RecoveryOperation(Operation):
         remote_ssh_command = job_content.get("remote_ssh_command")
 
         if TYPE_CHECKING:  # pragma: no cover
+            assert isinstance(self.server.name, str)
             assert isinstance(backup_id, str)
             assert isinstance(destination_directory, str)
             assert isinstance(remote_ssh_command, str)
@@ -741,6 +742,7 @@ class ConfigSwitchOperation(Operation):
         reset = job_content.get("reset")
 
         if TYPE_CHECKING:  # pragma: no cover
+            assert isinstance(self.server.name, str)
             assert model_name is None or isinstance(model_name, str)
             assert reset is None or isinstance(reset, bool)
 

--- a/pg_backup_api/pg_backup_api/server_operation.py
+++ b/pg_backup_api/pg_backup_api/server_operation.py
@@ -71,15 +71,17 @@ class OperationNotExists(LookupError):
 
 class OperationServer:
     """
-    Contain metadata about a Barman server and logic to handle operations.
+    Contain logic to handle operations for a Barman instance or Barman server.
 
-    :ivar name: name of the Barman server.
-    :ivar config: Barman configuration of the Barman server.
+    :ivar name: name of the Barman server, if it's server operation, otherwise
+        ``None`` for a "global" (instance) operation.
+    :ivar config: Barman configuration of the Barman server, if it's a server
+        operation, otherwise ``None`` for a "global" (instance) operation.
     :ivar jobs_basedir: directory where to save files of operations that have
-        been created for this Barman server.
+        been created for this Barman server or instance.
     :ivar output_basedir: directory where to save files with output of
-        operations that have been finished for this Barman server -- both for
-        failed and successful executions.
+        operations that have been finished for this Barman server or instance
+        -- both for failed and successful executions.
     """
 
     # Name of the pg-backup-api ``jobs`` directory. Files created under this
@@ -94,27 +96,33 @@ class OperationServer:
     # Set of required keys when creating an operation output file.
     _REQUIRED_OUTPUT_KEYS = ("success", "end_time", "output",)
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: Optional[str]) -> None:
         """
         Initialize a new instance of :class:`OperationServer`.
 
-        Fill all the metadata required by pg-backup-api of a given Barman
-        server named *name*, if it exists in Barman. Also prepare the Barman
-        server to execute pg-backup-api operations.
+        Fill all the metadata required by pg-backup-api for a given Barman
+        server named *name*, if a Barman server opartion and the server exists
+        in Barman. Also prepare the Barman server or instance to execute
+        pg-backup-api operations.
 
-        :param name: name of the Barman server.
+        :param name: name of the Barman server, if it's a Barman server
+            operation, ``None`` for a "global" (instance) operation.
 
         :raises:
             :exc:`OperationServerConfigError`: if no Barman configuration could
-                be found for server *name*.
+                be found for server *name*, in case of a Barman server
+                operation.
         """
         self.name = name
-        self.config = get_server_by_name(name)
+        self.config = None
 
-        if not self.config:
-            raise OperationServerConfigError(
-                f"No barman config found for '{name}'."
-            )
+        if name:
+            self.config = get_server_by_name(name)
+
+            if not self.config:
+                raise OperationServerConfigError(
+                    f"No barman config found for '{name}'."
+                )
 
         load_barman_config()
 
@@ -123,10 +131,15 @@ class OperationServer:
 
         barman_home = barman.__config__.barman_home
 
-        self.jobs_basedir = join(barman_home, name, self._JOBS_DIR_NAME)
-        self._create_jobs_dir()
+        if name:
+            self.jobs_basedir = join(barman_home, name, self._JOBS_DIR_NAME)
+            self.output_basedir = join(barman_home, name,
+                                       self._OUTPUT_DIR_NAME)
+        else:
+            self.jobs_basedir = join(barman_home, self._JOBS_DIR_NAME)
+            self.output_basedir = join(barman_home, self._OUTPUT_DIR_NAME)
 
-        self.output_basedir = join(barman_home, name, self._OUTPUT_DIR_NAME)
+        self._create_jobs_dir()
         self._create_output_dir()
 
     @staticmethod
@@ -151,11 +164,11 @@ class OperationServer:
             os.makedirs(dir_path)
 
     def _create_jobs_dir(self) -> None:
-        """Create the ``jobs`` directory of this Barman server."""
+        """Create the ``jobs`` directory of Barman server or instance."""
         self._create_dir(self.jobs_basedir)
 
     def _create_output_dir(self) -> None:
-        """Create the ``outputs`` directory of this Barman server."""
+        """Create the ``outputs`` directory of Barman server or instance."""
         self._create_dir(self.output_basedir)
 
     def get_job_file_path(self, op_id: str) -> str:
@@ -318,16 +331,16 @@ class OperationServer:
     def get_operations_list(self, op_type: Optional[OperationType] = None) \
             -> List[Dict[str, Any]]:
         """
-        Get the list of operations of this Barman server.
+        Get the list of operations of this Barman server or instance.
 
         Fetch operation from all ``.json`` files found under the
-        :attr:`jobs_basedir` of this server.
+        :attr:`jobs_basedir` of this server or instance.
 
         :param op_type: if ``None`` retrieve all operations. If something other
             than ``None``, filter by the given type.
 
-        :return: list of operations of this Barman server. Each item has the
-            following keys:
+        :return: list of operations of this Barman server or instance. Each
+            item has the following keys:
 
             * ``id``: ID of the operation;
             * ``type``: type of the operation.
@@ -393,12 +406,13 @@ class Operation:
     :ivar id: ID of this operation.
     """
 
-    def __init__(self, server_name: str, id: Optional[str] = None) -> None:
+    def __init__(self, server_name: Optional[str],
+                 id: Optional[str] = None) -> None:
         """
         Initialize a new instance of :class:`Operation`.
 
-        :param server_name: name of the Barman server, so we can manage this
-            operation.
+        :param server_name: name of the Barman server, in case of a Barman
+            server operation, ``None`` in case of a Barman instance operation.
         :param id: ID of the operation. Useful when querying an existing
             operation. Use ``None`` when creating an operation, so this class
             generates a new ID.
@@ -789,7 +803,7 @@ if __name__ == "__main__":
                     "get information about jobs without a running REST API.",
     )
     parser.add_argument(
-        "--server-name", required=True,
+        "--server-name",
         help="Name of the Barman server related to the operation.",
     )
     parser.add_argument(

--- a/pg_backup_api/pg_backup_api/tests/test_main.py
+++ b/pg_backup_api/pg_backup_api/tests/test_main.py
@@ -28,10 +28,11 @@ from pg_backup_api.__main__ import main
 
 _HELP_OUTPUT = {
     "pg-backup-api --help": dedent("""\
-        usage: pg-backup-api [-h] {serve,status,recovery,config-switch} ...
+        usage: pg-backup-api [-h]
+                             {serve,status,recovery,config-switch,config-update} ...
 
         positional arguments:
-          {serve,status,recovery,config-switch}
+          {serve,status,recovery,config-switch,config-update}
 
         optional arguments:
           -h, --help            show this help message and exit
@@ -91,6 +92,18 @@ _HELP_OUTPUT = {
                                 ID of the operation in the 'pg-backup-api'.
 \
     """),  # noqa: E501
+    "pg-backup-api config-update --help": dedent("""\
+        usage: pg-backup-api config-update [-h] --operation-id OPERATION_ID
+
+        Perform a 'barman config-update' through the 'pg-backup-api'. Can only be run
+        if a config-update operation has been previously registered.
+
+        optional arguments:
+          -h, --help            show this help message and exit
+          --operation-id OPERATION_ID
+                                ID of the operation in the 'pg-backup-api'.
+\
+    """),  # noqa: E501
 }
 
 _COMMAND_FUNC = {
@@ -98,6 +111,7 @@ _COMMAND_FUNC = {
     "pg-backup-api status": "status",
     "pg-backup-api recovery --server-name SOME_SERVER --operation-id SOME_OP_ID": "recovery_operation",  # noqa: E501
     "pg-backup-api config-switch --server-name SOME_SERVER --operation-id SOME_OP_ID": "config_switch_operation",  # noqa: E501
+    "pg-backup-api config-update --operation-id SOME_OP_ID": "config_update_operation",  # noqa: E501
 }
 
 

--- a/pg_backup_api/pg_backup_api/tests/test_main.py
+++ b/pg_backup_api/pg_backup_api/tests/test_main.py
@@ -39,7 +39,7 @@ _HELP_OUTPUT = {
 
         Postgres Backup API by EnterpriseDB (www.enterprisedb.com)
 \
-    """),
+    """),  # noqa: E501
     "pg-backup-api serve --help": dedent("""\
         usage: pg-backup-api serve [-h] [--port PORT]
 

--- a/pg_backup_api/pg_backup_api/tests/test_run.py
+++ b/pg_backup_api/pg_backup_api/tests/test_run.py
@@ -166,7 +166,7 @@ def test_config_switch_operation(mock_cs_op, server_name, operation_id, rc):
 @pytest.mark.parametrize("operation_id", ["OPERATION_1", "OPERATION_2"])
 @pytest.mark.parametrize("rc", [0, 1])
 @patch("pg_backup_api.run.ConfigUpdateOperation")
-def test_config_switch_operation(mock_cu_op, operation_id, rc):
+def test_config_update_operation(mock_cu_op, operation_id, rc):
     """Test :func:`config_update_operation`.
 
     Ensure the operation is created and executed, and that the expected values

--- a/pg_backup_api/pg_backup_api/tests/test_run.py
+++ b/pg_backup_api/pg_backup_api/tests/test_run.py
@@ -25,7 +25,8 @@ from unittest.mock import MagicMock, patch, call
 import pytest
 
 from pg_backup_api.run import (serve, status, recovery_operation,
-                               config_switch_operation)
+                               config_switch_operation,
+                               config_update_operation)
 
 
 @pytest.mark.parametrize("port", [7480, 7481])
@@ -147,6 +148,42 @@ def test_config_switch_operation(mock_cs_op, server_name, operation_id, rc):
 
     mock_cs_op.assert_called_once_with(server_name, operation_id)
     mock_cs_op.return_value.run.assert_called_once_with()
+    mock_time_event.assert_called_once_with()
+    mock_read_job.assert_called_once_with()
+
+    # Make sure the expected content was added to `read_job_file` output before
+    # writing it to the output file.
+    assert len(mock_read_job.return_value.__setitem__.mock_calls) == 3
+    mock_read_job.return_value.__setitem__.assert_has_calls([
+        call('success', rc == 0),
+        call('end_time', mock_time_event.return_value),
+        call('output', "SOME_OUTPUT"),
+    ])
+
+    mock_write_output.assert_called_once_with(mock_read_job.return_value)
+
+
+@pytest.mark.parametrize("operation_id", ["OPERATION_1", "OPERATION_2"])
+@pytest.mark.parametrize("rc", [0, 1])
+@patch("pg_backup_api.run.ConfigUpdateOperation")
+def test_config_switch_operation(mock_cu_op, operation_id, rc):
+    """Test :func:`config_update_operation`.
+
+    Ensure the operation is created and executed, and that the expected values
+    are returned depending on the return code.
+    """
+    args = argparse.Namespace(operation_id=operation_id)
+
+    mock_cu_op.return_value.run.return_value = ("SOME_OUTPUT", rc)
+    mock_write_output = mock_cu_op.return_value.write_output_file
+    mock_time_event = mock_cu_op.return_value.time_event_now
+    mock_read_job = mock_cu_op.return_value.read_job_file
+
+    assert config_update_operation(args) == (mock_write_output.return_value,
+                                             rc == 0)
+
+    mock_cu_op.assert_called_once_with(None, operation_id)
+    mock_cu_op.return_value.run.assert_called_once_with()
     mock_time_event.assert_called_once_with()
     mock_read_job.assert_called_once_with()
 

--- a/pg_backup_api/pg_backup_api/tests/test_server_operation.py
+++ b/pg_backup_api/pg_backup_api/tests/test_server_operation.py
@@ -31,6 +31,7 @@ from pg_backup_api.server_operation import (
     Operation,
     RecoveryOperation,
     ConfigSwitchOperation,
+    ConfigUpdateOperation,
 )
 
 
@@ -1051,4 +1052,95 @@ class TestConfigSwitchOperation:
         mock_get_args.assert_called_once()
         mock_run_subprocess.assert_called_once_with(
             ["barman", "config-switch"] + arguments,
+        )
+
+
+@patch("pg_backup_api.server_operation.OperationServer", MagicMock())
+class TestConfigUpdateOperation:
+    """Run tests for :class:`ConfigUpdateOperation`."""
+
+    @pytest.fixture
+    @patch("pg_backup_api.server_operation.OperationServer", MagicMock())
+    def operation(self):
+        """Create a :class:`ConfigUpdateOperation` instance for testing.
+
+        :return: a new instance of :class:`ConfigUpdateOperation` for testing.
+        """
+        return ConfigUpdateOperation(None)
+
+    def test__validate_job_content_content_missing_keys(self, operation):
+        """Test :meth:`ConfigUpdateOperation._validate_job_content`.
+
+        Ensure an exception is raised if the content is missing the required
+        keys.
+        """
+        with pytest.raises(MalformedContent) as exc:
+            operation._validate_job_content({})
+
+        assert str(exc.value) == (
+            "Missing required arguments: changes"
+        )
+
+    def test__validate_job_content_ok(self, operation):
+        """Test :meth:`ConfigUpdateOperation._validate_job_content`.
+
+        Ensure execution is fine if required keys are giving.
+        """
+        operation._validate_job_content({"changes": "SOME_CHANGES"})
+
+    @patch("pg_backup_api.server_operation.Operation.time_event_now")
+    @patch("pg_backup_api.server_operation.Operation.write_job_file")
+    def test_write_job_file(self, mock_write_job_file, mock_time_event_now,
+                            operation):
+        """Test :meth:`ConfigUpdateOperation.write_job_file`.
+
+        Ensure the underlying methods are called as expected.
+        """
+        content = {
+            "SOME": "CONTENT",
+        }
+        extended_content = {
+            "SOME": "CONTENT",
+            "operation_type": OperationType.CONFIG_UPDATE.value,
+            "start_time": "SOME_TIMESTAMP",
+        }
+
+        with patch.object(operation, "_validate_job_content") as mock:
+            mock_time_event_now.return_value = "SOME_TIMESTAMP"
+
+            operation.write_job_file(content)
+
+            mock_time_event_now.assert_called_once()
+            mock.assert_called_once_with(extended_content)
+            mock_write_job_file.assert_called_once_with(extended_content)
+
+    def test__get_args(self, operation):
+        """Test :meth:`ConfigUpdateOperation._get_args`.
+
+        Ensure it returns the correct arguments for ``barman config-update``.
+        """
+        with patch.object(operation, "read_job_file") as mock:
+            mock.return_value = {"changes": [{"SOME": "CHANGES"}]}
+
+            expected = ['[{"SOME": "CHANGES"}]']
+            assert operation._get_args() == expected
+
+    @patch("pg_backup_api.server_operation.Operation._run_subprocess")
+    @patch("pg_backup_api.server_operation.ConfigUpdateOperation._get_args")
+    def test__run_logic(self, mock_get_args, mock_run_subprocess, operation):
+        """Test :meth:`ConfigUpdateOperation._run_logic`.
+
+        Ensure the underlying calls occur as expected.
+        """
+        arguments = ["SOME", "ARGUMENTS"]
+        output = ("SOME OUTPUT", 0)
+
+        mock_get_args.return_value = arguments
+        mock_run_subprocess.return_value = output
+
+        assert operation._run_logic() == output
+
+        mock_get_args.assert_called_once()
+        mock_run_subprocess.assert_called_once_with(
+            ["barman", "config-update"] + arguments,
         )


### PR DESCRIPTION
So far we had only operations related with Barman servers in the API:

* `RecoveryOperation`: to perform a `barman recover` of a Barman server
* `ConfigSwitchOperation`: to perform a `barman config-switch` to a Barman server

However, we needed to add an operation to the API which is performed at the Barman instance level (global), not to a specific Barman server: the `ConfigUpdateOperation`.

With that in mind this PR changes the classes below so we will be able to create Barman instance operations:

* `OperationServer`: turn `server_name` argument optional. When it is `None`, that is considered an instance operation. Thus, the `job` and `output` files will be written under the Barman home in that case instead of under a Barman server directory
* `Operation`: turn `server_name` argument optional, so it creates `OperationServer` accordingly

We also added a couple new endpoints to the API, so we can handle instance operations:

* `/operations/<operation_id>`: used to get the status of an instance operation -- similar to what we have for server operations through `/servers/<server_name>/operations/<operation_id>`;
* `/operations`: used to get a list of or instance operations, or to create a new instance operation -- similar to what we have for server operations through `/servers/<server_name>/operations`.

The `BarmanConfigUpdate` operation has been created and uses the above API endpoints.

Unit tests changed accordingly, so we check both server and instance operations, including the introduced operation.

References: BAR-126.